### PR TITLE
Fix issue where rev detection fails with additional JSON files

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function _getManifestData(file, opts) {
         if (_.isObject(json)) {
             var isRev = 1;
             Object.keys(json).forEach(function (key) {
-                if ( path.basename(json[key]).replace(new RegExp( opts.revSuffix ), '' ) !==  path.basename(key) ) {
+                if ( !_.isString(json[key]) || path.basename(json[key]).replace(new RegExp( opts.revSuffix ), '' ) !==  path.basename(key) ) {
                     isRev = 0;
                 }
             });


### PR DESCRIPTION
I have a `copy` task that copies over additional supporting files which include a `manifest.json` that is necessary for add to homescreen on Android.  Currently copying this JSON file fails with `gulp-rev-collector` because it tries to take `path.basename` of an object.  This PR adds a check to make sure the value is a string, fixing that error.

For reference, this is the JSON file that breaks the package (since it tries to take `path.basename` of the `icons` array):

```json
{
  "name": "Half Staff",
  "icons": [
    {
      "src": "/images/icons/android-chrome-36x36.png",
      "sizes": "36x36",
      "type": "image/png",
      "density": 0.75
    },
    {
      "src": "/images/icons/android-chrome-48x48.png",
      "sizes": "48x48",
      "type": "image/png",
      "density": 1
    },
    {
      "src": "/images/icons/android-chrome-72x72.png",
      "sizes": "72x72",
      "type": "image/png",
      "density": 1.5
    },
    {
      "src": "/images/icons/android-chrome-96x96.png",
      "sizes": "96x96",
      "type": "image/png",
      "density": 2
    },
    {
      "src": "/images/icons/android-chrome-144x144.png",
      "sizes": "144x144",
      "type": "image/png",
      "density": 3
    },
    {
      "src": "/images/icons/android-chrome-192x192.png",
      "sizes": "192x192",
      "type": "image/png",
      "density": 4
    }
  ],
  "start_url": "https://halfstaff.co",
  "display": "standalone"
}
```